### PR TITLE
Make it easier to translate the clap --help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,10 +105,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-i18n-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap-i18n-richformatter"
 version = "0.1.4"
 dependencies = [
  "clap",
+ "clap-i18n-derive",
  "i18n-embed",
  "i18n-embed-fl",
  "rust-embed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,14 @@ i18n-embed-fl = "0.10"
 rust-embed = "8.5.0"
 unic-langid = "0.9.5"
 clap = "4"
+clap-i18n-derive = { path = "clap-i18n-derive", optional = true }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
+
+[features]
+default = ["derive"]
+derive = ["dep:clap-i18n-derive"]
+
+[workspace]
+members = ["clap-i18n-derive"]

--- a/clap-i18n-derive/Cargo.toml
+++ b/clap-i18n-derive/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "clap-i18n-derive"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "Derive macro for clap-i18n-richformatter"
+repository = "https://github.com/mkrueger/clap-i18n-richformatter"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full", "parsing"] }

--- a/clap-i18n-derive/src/lib.rs
+++ b/clap-i18n-derive/src/lib.rs
@@ -1,0 +1,173 @@
+//! Derive macro for clap-i18n-richformatter
+//!
+//! This crate provides the `#[clap_i18n]` attribute macro that adds
+//! internationalized help and version flags to clap command structs.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, parse_macro_input};
+
+/// Adds i18n support for clap help and version flags.
+///
+/// This attribute macro:
+/// - Disables the built-in help and version flags
+/// - Implements a custom `CommandFactory` that adds translated help and version args
+///
+/// # Example
+/// ```ignore
+/// use clap::Parser;
+/// use clap_i18n_richformatter::clap_i18n;
+///
+/// #[derive(Parser)]
+/// #[clap_i18n]
+/// struct MyArgs {
+///     #[arg(long)]
+///     name: String,
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn clap_i18n(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as DeriveInput);
+
+    let name = &input.ident;
+    let vis = &input.vis;
+    let attrs = &input.attrs;
+    let generics = &input.generics;
+    let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
+
+    // Extract existing fields
+    let fields = match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(fields) => &fields.named,
+            _ => {
+                return syn::Error::new_spanned(
+                    &input,
+                    "clap_i18n only supports structs with named fields",
+                )
+                .to_compile_error()
+                .into();
+            }
+        },
+        _ => {
+            return syn::Error::new_spanned(&input, "clap_i18n only supports structs")
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    let existing_fields = fields.iter();
+
+    let expanded = quote! {
+        #(#attrs)*
+        #vis struct #name #impl_generics #where_clause {
+            #(#existing_fields,)*
+        }
+
+        impl #name {
+            /// Returns a clap Command with i18n-translated help and version flags.
+            pub fn command_i18n() -> clap::Command {
+                use clap::CommandFactory;
+
+                // Get translated strings at runtime (no compile-time validation)
+                let usage_heading: &'static str = Box::leak(
+                    clap_i18n_richformatter::__private::get_translation("clap-usage-heading").into_boxed_str()
+                );
+                let options_heading: &'static str = Box::leak(
+                    clap_i18n_richformatter::__private::get_translation("clap-options-heading").into_boxed_str()
+                );
+                let commands_heading: &'static str = Box::leak(
+                    clap_i18n_richformatter::__private::get_translation("clap-commands-heading").into_boxed_str()
+                );
+                let help_help: &'static str = Box::leak(
+                    clap_i18n_richformatter::__private::get_translation("clap-help-help").into_boxed_str()
+                );
+                let version_help: &'static str = Box::leak(
+                    clap_i18n_richformatter::__private::get_translation("clap-help-version").into_boxed_str()
+                );
+
+                let arguments_heading: &'static str = Box::leak(
+                    clap_i18n_richformatter::__private::get_translation("clap-arguments-heading").into_boxed_str()
+                );
+
+                let help_template: &'static str = Box::leak(format!(
+                    "{{about-with-newline}}\n\
+                    {usage_heading} {{usage}}\n\
+                    \n\
+                    {{all-args}}\
+                    {{after-help}}"
+                ).into_boxed_str());
+
+                let mut cmd = Self::command()
+                    // Disable built-in help and version
+                    .disable_help_flag(true)
+                    .disable_version_flag(true)
+                    // Set translated help template
+                    .help_template(help_template)
+                    // Translate section headings via clap's heading API
+                    .next_display_order(900)
+                    .next_help_heading(options_heading)
+                    .subcommand_help_heading(commands_heading)
+                    .subcommand_value_name(commands_heading);
+
+                // Update all positional arguments to use translated heading
+                let positional_ids: Vec<_> = cmd.get_positionals()
+                    .map(|a| a.get_id().clone())
+                    .collect();
+
+                for id in positional_ids {
+                    cmd = cmd.mut_arg(id, |a| a.help_heading(arguments_heading));
+                }
+
+                // Update all option arguments to use translated heading
+                let option_ids: Vec<_> = cmd.get_opts()
+                    .map(|a| a.get_id().clone())
+                    .collect();
+
+                for id in option_ids {
+                    cmd = cmd.mut_arg(id, |a| a.help_heading(options_heading));
+                }
+
+                // Add translated help and version args
+                cmd.arg(
+                        clap::Arg::new("help")
+                            .short('h')
+                            .long("help")
+                            .action(clap::ArgAction::Help)
+                            .help(help_help)
+                            .global(true)
+                    )
+                    .arg(
+                        clap::Arg::new("version")
+                            .short('V')
+                            .long("version")
+                            .action(clap::ArgAction::Version)
+                            .help(version_help)
+                            .global(true)
+                    )
+            }
+
+            /// Parse arguments with i18n-translated help, version, and error messages.
+            /// Automatically initializes the localizer.
+            /// Returns a Result with the parsed args or a clap::Error.
+            pub fn parse_i18n() -> Result<Self, clap::error::Error<clap_i18n_richformatter::ClapI18nRichFormatter>> {
+                use clap::FromArgMatches;
+                clap_i18n_richformatter::init_clap_rich_formatter_localizer();
+                Self::command_i18n()
+                    .try_get_matches()
+                    .and_then(|matches| Self::from_arg_matches(&matches))
+                    .map_err(|e| {
+                        e.apply::<clap_i18n_richformatter::ClapI18nRichFormatter>()
+                    })
+            }
+
+            /// Parse arguments and exit on error with formatted i18n message.
+            /// Automatically initializes the localizer.
+            /// Use this for simple CLI apps that should exit on parse errors.
+            pub fn parse_i18n_or_exit() -> Self {
+                Self::parse_i18n().unwrap_or_else(|e| e.exit())
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/clap-i18n-derive/src/lib.rs
+++ b/clap-i18n-derive/src/lib.rs
@@ -89,13 +89,17 @@ pub fn clap_i18n(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     clap_i18n_richformatter::__private::get_translation("clap-arguments-heading").into_boxed_str()
                 );
 
-                let help_template: &'static str = Box::leak(format!(
-                    "{{about-with-newline}}\n\
-                    {usage_heading} {{usage}}\n\
-                    \n\
-                    {{all-args}}\
-                    {{after-help}}"
-                ).into_boxed_str());
+                // Build help template with styled usage heading (bold + underline like other headings)
+                let help_template: clap::builder::StyledStr = {
+                    use std::fmt::Write;
+                    use clap::builder::styling::{Style, Effects};
+                    let mut s = clap::builder::StyledStr::new();
+                    let header = Style::new().effects(Effects::BOLD | Effects::UNDERLINE);
+                    let _ = write!(s, "{{before-help}}{{about-with-newline}}\n");
+                    let _ = write!(s, "{header}{usage_heading}{header:#} {{usage}}\n\n");
+                    let _ = write!(s, "{{all-args}}{{after-help}}");
+                    s
+                };
 
                 let mut cmd = Self::command()
                     // Disable built-in help and version

--- a/examples/i18n_example.rs
+++ b/examples/i18n_example.rs
@@ -1,0 +1,24 @@
+use clap::Parser;
+use clap_i18n_richformatter::clap_i18n;
+
+#[derive(Debug, Parser)]
+#[clap_i18n]
+#[command(version, about = "An example program with i18n support")]
+struct Args {
+    /// The input file
+    #[arg(short, long)]
+    input: Option<String>,
+
+    /// Enable verbose output
+    #[arg(short, long)]
+    verbose: bool,
+
+    /// Number of repetitions
+    #[arg(short, long, default_value = "1")]
+    count: u32,
+}
+
+fn main() {
+    let args = Args::parse_i18n_or_exit();
+    println!("{args:?}");
+}

--- a/examples/positional_example.rs
+++ b/examples/positional_example.rs
@@ -1,0 +1,24 @@
+use clap::Parser;
+use clap_i18n_richformatter::clap_i18n;
+
+#[derive(Debug, Parser)]
+#[clap_i18n]
+#[command(version, about = "Example with positional arguments")]
+struct Args {
+    /// The URL to connect to
+    #[arg(value_name = "URL")]
+    url: Option<String>,
+
+    /// A script to run
+    #[arg(short, long)]
+    run: Option<String>,
+
+    /// Enable debug mode
+    #[arg(short, long)]
+    debug: bool,
+}
+
+fn main() {
+    let args = Args::parse_i18n().unwrap_or_else(|e| e.exit());
+    println!("{args:?}");
+}

--- a/i18n/de-DE/clap_i18n_richformatter.ftl
+++ b/i18n/de-DE/clap_i18n_richformatter.ftl
@@ -41,7 +41,10 @@ clap-value-context = { $multi ->
 }
 clap-error-heading = Fehler
 clap-tip-heading = Hinweis
-clap-usage-heading = Verwendung:
+clap-usage-heading = Aufruf:
+clap-arguments-heading = Argumente
+clap-options-heading = Optionen
+clap-commands-heading = Befehle
 clap-packages-value-name = PAKETE
 clap-dyn-errorkind-unexpected-arg = Unerwartetes Argument '{ $arg }' gefunden
 clap-dyn-errorkind-too-few-values = { $n ->
@@ -53,3 +56,5 @@ clap-dyn-errorkind-wrong-number-of-values = { $n ->
     *[other] { $num_values } Werte werden von '{ $invalid_arg }' benötigt; aber '{ $actual_num_values }' wurde angegeben
 }
 clap-dyn-errorkind-value-validation = Ungültiger Wert '{ $invalid_value }' für '{ $invalid_arg }'
+clap-help-help = Hilfe anzeigen (Zusammenfassung mit '-h')
+clap-help-version = Version anzeigen

--- a/i18n/en-US/clap_i18n_richformatter.ftl
+++ b/i18n/en-US/clap_i18n_richformatter.ftl
@@ -42,6 +42,9 @@ clap-value-context = { $multi ->
 clap-error-heading = error
 clap-tip-heading = tip
 clap-usage-heading = Usage:
+clap-arguments-heading = Arguments
+clap-options-heading = Options
+clap-commands-heading = Commands
 clap-packages-value-name = PACKAGES
 clap-dyn-errorkind-unexpected-arg = unexpected argument '{ $arg }' found
 clap-dyn-errorkind-too-few-values = { $n ->
@@ -53,3 +56,5 @@ clap-dyn-errorkind-wrong-number-of-values = { $n ->
     *[other] { $num_values } values required by '{ $invalid_arg }'; but '{ $actual_num_values }' was provided
 }
 clap-dyn-errorkind-value-validation = invalid value '{ $invalid_value }' for '{ $invalid_arg }'
+clap-help-help = Print help (see a summary with '-h')
+clap-help-version = Print version

--- a/i18n/zh-CN/clap_i18n_richformatter.ftl
+++ b/i18n/zh-CN/clap_i18n_richformatter.ftl
@@ -28,9 +28,15 @@ clap-argument-context = 参数
 clap-error-heading = 错误
 clap-tip-heading = 小贴士
 clap-usage-heading = 用法:
+clap-arguments-heading = 参数
+clap-options-heading = 选项
+clap-commands-heading = 命令
 clap-dyn-errorkind-unexpected-arg = 不支持该参数 '{ $arg }'
 clap-possible-value-context = 可能的值
 clap-value-context = 值
 clap-dyn-errorkind-too-few-values = { $invalid_arg } 预期 { $num_values }  个参数，但仅指定 { $actual_num_values } 个
 clap-dyn-errorkind-wrong-number-of-values = { $invalid_arg } 预期 { $num_values }  个参数，但指定了 { $actual_num_values } 个
 clap-dyn-errorkind-value-validation = 对于参数 '{ $invalid_arg }' 而言，'{ $invalid_value }' 是无效的值
+
+clap-help-help = 打印帮助信息（使用 '-h' 查看摘要）
+clap-help-version = 打印版本信息

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -20,13 +20,20 @@ pub static CLAP_I18N_LANGUAGE_LOADER: LazyLock<FluentLanguageLoader> = LazyLock:
     loader
 });
 
-#[macro_export]
+/// Get a translated string by message ID (runtime lookup, no compile-time validation)
+#[doc(hidden)]
+pub fn get_translation(message_id: &str) -> String {
+    CLAP_I18N_LANGUAGE_LOADER.get(message_id)
+}
+
 macro_rules! fl {
     ($message_id:literal) => {{
-        i18n_embed_fl::fl!($crate::lang::CLAP_I18N_LANGUAGE_LOADER, $message_id)
+        i18n_embed_fl::fl!(crate::lang::CLAP_I18N_LANGUAGE_LOADER, $message_id)
     }};
 
     ($message_id:literal, $($args:expr),*) => {{
-        i18n_embed_fl::fl!($crate::lang::CLAP_I18N_LANGUAGE_LOADER, $message_id, $($args), *)
+        i18n_embed_fl::fl!(crate::lang::CLAP_I18N_LANGUAGE_LOADER, $message_id, $($args), *)
     }};
 }
+
+pub(crate) use fl;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,19 @@ use i18n_embed::Localizer;
 
 use crate::lang::CLAP_I18N_LANGUAGE_LOADER;
 pub use crate::lang::ClapI18nLocalizations;
+use crate::lang::fl;
 
 mod lang;
+
+// Re-export the derive macro
+#[cfg(feature = "derive")]
+pub use clap_i18n_derive::clap_i18n;
+
+// Hidden module for internal use by derive macro (not shown in code completion)
+#[doc(hidden)]
+pub mod __private {
+    pub use crate::lang::get_translation;
+}
 
 const TAB: &str = "  ";
 


### PR DESCRIPTION
I played around a bit with proc-macros and maybe I've a solution to translate the --help fully.

...
#[clap_i18n]
struct Args {
}
....

    let args = Args::parse_i18n_or_exit();
....

Added some missing keys. 

 "init_clap_rich_formatter_localizer();"  is handled by the parse_i18n_or_exit();.
 
Note there is a parse_i18n() with Result<> as well but then help doesn't work anymore so nicely - it's returned as err result.
 
But I want first hear opinions. I'm not up2date with clap discussions maybe they'll add a better way for adding translations?.

IDK if the idea is good - it's basically building an own help output :). But ATM I don't have any better approach. I just want it translated.